### PR TITLE
Simplify poms

### DIFF
--- a/beanshooter/pom.xml
+++ b/beanshooter/pom.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+<project>
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+<project>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.qtc.beanshooter</groupId>
@@ -15,5 +12,4 @@
         <module>tonka-bean</module>
         <module>beanshooter</module>
     </modules>
-
 </project>

--- a/tonka-bean/pom.xml
+++ b/tonka-bean/pom.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+<project>
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -58,5 +55,6 @@
               </executions>
           </plugin>
         </plugins>
+
     </build>
 </project>


### PR DESCRIPTION
During the preparation of the release candidates, the pom files were
adpoted to show the correct version number. However, these changes were
never reflected in develop and the pom related commits on master were
treated as the current and newer version. Therefore, they still pointed
at the release candidate version and we needed to update the pom files.
To add at least some work in this commit, we simplified the poms by
removing the unused namespaces.