### PR TITLE
Add support for tonka exec output decoding with specified charset

### DIFF
--- a/beanshooter/src/de/qtc/beanshooter/mbean/tonkabean/Dispatcher.java
+++ b/beanshooter/src/de/qtc/beanshooter/mbean/tonkabean/Dispatcher.java
@@ -1,9 +1,6 @@
 package de.qtc.beanshooter.mbean.tonkabean;
 
-import java.io.Console;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.lang.reflect.Proxy;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
@@ -152,7 +149,25 @@ public class Dispatcher extends de.qtc.beanshooter.mbean.Dispatcher
             else
             {
                 Logger.printlnYellow("Server response:");
-                System.out.write(result);
+
+                if (TonkaBeanOption.EXEC_CHARSET.notNull()){
+                    String charset = TonkaBeanOption.EXEC_CHARSET.<String>getValue();
+
+                    InputStream is = new ByteArrayInputStream(result);
+                    Reader reader = new InputStreamReader(is, charset);
+                    BufferedReader br = new BufferedReader(reader);
+
+                    String s;
+                    while((s=br.readLine()) != null) {
+                        System.out.println(s);
+                    }
+
+                    br.close();
+                }
+
+                else{
+                    System.out.write(result);
+                }
             }
         }
 

--- a/beanshooter/src/de/qtc/beanshooter/mbean/tonkabean/TonkaBeanOperation.java
+++ b/beanshooter/src/de/qtc/beanshooter/mbean/tonkabean/TonkaBeanOperation.java
@@ -67,6 +67,7 @@ public enum TonkaBeanOperation implements Operation
             TonkaBeanOption.EXEC_FILE,
             TonkaBeanOption.EXEC_HEX,
             TonkaBeanOption.EXEC_RAW,
+            TonkaBeanOption.EXEC_CHARSET,
             TonkaBeanOption.EXEC_BACK,
             TonkaBeanOption.SHELL_CMD,
     }),
@@ -99,6 +100,7 @@ public enum TonkaBeanOperation implements Operation
             TonkaBeanOption.EXEC_FILE,
             TonkaBeanOption.EXEC_HEX,
             TonkaBeanOption.EXEC_RAW,
+            TonkaBeanOption.EXEC_CHARSET,
             TonkaBeanOption.EXEC_BACK,
     }),
 

--- a/beanshooter/src/de/qtc/beanshooter/mbean/tonkabean/TonkaBeanOption.java
+++ b/beanshooter/src/de/qtc/beanshooter/mbean/tonkabean/TonkaBeanOption.java
@@ -76,6 +76,13 @@ public enum TonkaBeanOption implements Option
              ArgType.BOOL
              ),
 
+    EXEC_CHARSET("--charset",
+            "decode the output of the command with specific charset",
+                Arguments.store(),
+                OptionGroup.ACTION,
+                ArgType.STRING
+                ),
+
     UPLOAD_SOURCE("local",
                   "local file to upload onto the server",
                   Arguments.store(),


### PR DESCRIPTION
In the beginning beanshooter does not decode the output of `tonka exec`. It just `write`s the original bytes to console without any side effect. So I think it could be even better if we add an option to decode the output with specified charset to string!

PS: I kept the code format carefully because there is no editorconfig file.